### PR TITLE
Docker tweaks for Mac Development

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,3 +13,7 @@ run:
 .PHONY: browser
 browser:
 	chromium http://$(shell docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' $(shell docker-compose -f docker/docker-compose.yml ps -q dashboard |tail -n1)):8080/
+
+.PHONY: mac-browser
+mac-browser:
+	open -a firefox http://127.0.0.1:$(shell docker inspect -f '{{(index (index .NetworkSettings.Ports "8080/tcp") 0).HostPort}}' $(shell docker-compose -f docker/docker-compose.yml ps -q dashboard |tail -n1))/

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -6,6 +6,8 @@ services:
       dockerfile: docker/Dockerfile
     volumes:
       - ..:/home/user/dashboard
+    ports:
+      - 8080
 
   dashboard-test:
     build:


### PR DESCRIPTION
Docker on Mac is slightly different, so we updated the `docker-compose.yml` to specify port and added `make mac-browser` to open Firefox on my computer.